### PR TITLE
Disable Busy Timeout message if Serial not initialized

### DIFF
--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -106,7 +106,10 @@ void GxEPD2_EPD::_waitWhileBusy(const char* comment, uint16_t busy_time)
       delay(1);
       if (micros() - start > _busy_timeout)
       {
-        Serial.println("Busy Timeout!");
+        if (_diag_enabled)
+        {
+          Serial.println("Busy Timeout!");
+        }
         break;
       }
     }


### PR DESCRIPTION
If diagnostics is disabled, don't attempt to print Busy Timeout message, may cause some Arduino cores to freeze.